### PR TITLE
Update wsl.md; use Ubuntu 18.04 instead of 20.04

### DIFF
--- a/docs/wsl.md
+++ b/docs/wsl.md
@@ -42,7 +42,7 @@ You can achieve this step by:
 
 ### Step 3: Install Ubuntu 
 
-After restarting your computer, go to the <a href="https://aka.ms/wslstore">Microsoft Store</a> and get <a href="https://www.microsoft.com/en-sg/p/ubuntu-2004-lts/9n6svws3rx71?rtc=1&activetab=pivot:overviewtab">Ubuntu</a>.
+After restarting your computer, go to the <a href="https://aka.ms/wslstore">Microsoft Store</a> and get <a href="https://www.microsoft.com/store/productId/9N9TNGVNDL3Q">Ubuntu</a>.
 
 Follow the on-screen instructions to install.  
 


### PR DESCRIPTION
According to [this post on Ubuntu Discourse](https://discourse.ubuntu.com/t/ubuntu-20-04-and-wsl-1/15291/3), Ubuntu 20.04 is not 100% stable and bug-free on WSL1. In fact, due to a number of issues referenced in that thread, it might even be that those are unfixable for WSL1. (From my limited understanding it seems to have to do with some system calls that don't translate well). 

I updated the link to go to the download for Ubuntu 18.04 LTS, which will be supported till 2023; I think this is sufficient (and much better than using the newest non-LTS version compatible with WSL1, 19.10, support for which ends soon). 